### PR TITLE
Fix k8s package repository authentication issue

### DIFF
--- a/resources/gcloud-setup/controlplane.sh
+++ b/resources/gcloud-setup/controlplane.sh
@@ -65,6 +65,7 @@ echo \
   "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
   "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update
 apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 # write append "127.0.0.1 private-registry.io"  to /etc/hosts if not exists
@@ -117,7 +118,7 @@ podman login private-registry.io:5000 -u testuser -p testpassword --tls-verify=f
 ### install packages
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 mkdir -p /etc/apt/keyrings
-curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 retries=5
 for _ in $(seq 1 $retries); do

--- a/resources/gcloud-setup/worker.sh
+++ b/resources/gcloud-setup/worker.sh
@@ -59,7 +59,7 @@ EOF
 ### install packages
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 mkdir -p /etc/apt/keyrings
-curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 retries=5
 for _ in $(seq 1 $retries); do


### PR DESCRIPTION
- issue
![image](https://github.com/flavono123/certified-kubernetes-trilogy/assets/93479706/12af7323-53ac-47ab-8ec5-7379ce3f5ce1)

- references
  - > The issues occurs because https://packages.cloud.google.com/apt/doc/apt-key.gpg is returning the GPG key as ASCII armored instead of binary. If you gpg --dearmor the key from packages.cloud.google.com apt is working again.
    - > https://github.com/kubernetes/website/issues/41246#issuecomment-1557060284

  - > https://github.com/kubernetes/release/issues/2862#issuecomment-1533888814



